### PR TITLE
Fix test mock to include Response.clone() method

### DIFF
--- a/tests/unit/common.test.ts
+++ b/tests/unit/common.test.ts
@@ -93,11 +93,14 @@ describe("API Class", () => {
 
     it("should handle request failure", async () => {
       const errorResponse = { message: "Not Found" };
-      (global.fetch as jest.Mock).mockResolvedValueOnce({
+      const mockResponse = {
         ok: false,
         status: 404,
         json: () => Promise.resolve(errorResponse),
-      });
+        clone: () => mockResponse,
+        text: () => Promise.resolve("Not Found"),
+      };
+      (global.fetch as jest.Mock).mockResolvedValueOnce(mockResponse);
 
       await expect(api.request("GET", "/test")).rejects.toThrow(APIError);
     });


### PR DESCRIPTION
## Summary
- Fixed test mock to include missing `clone()` and `text()` methods for fetch Response object
- Resolves TypeError: response.clone is not a function in test suite
- All tests now pass successfully

## Test plan
- ✅ All existing tests pass
- ✅ Fixed failing test: "should handle request failure"
- ✅ Test mock now properly simulates real Response object behavior

## Changes
- Updated mock Response object in `tests/unit/common.test.ts` to include `clone()` method
- Added `text()` method to mock for completeness
- Ensures test accurately reflects production code behavior

🤖 Generated with [Claude Code](https://claude.ai/code)