### PR TITLE
Fix CI workflow for co-located test structure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
-      - name: Run Unit Tests
-        run: npm test -- --testPathPattern=unit
+      - name: Run Tests
+        run: npm test
 
       - name: Build Package
         run: npm run build


### PR DESCRIPTION
## Summary
Update CI workflow to work with the new co-located test structure introduced in the URL construction refactor.

## Changes
- Remove hardcoded `--testPathPattern=unit` filter from CI workflow
- Use simple `npm test` command which works with Jest's updated configuration
- Ensures tests run correctly in CI environment with co-located structure

## Context  
The previous workflow expected tests in `tests/unit/` directory, but we've migrated to co-located tests in `src/` directory for better maintainability.

## Test plan
- [x] Tests run locally (12/12 passing)
- [x] Jest configuration properly discovers co-located tests
- [x] CI workflow will now find and run all tests correctly

🤖 Generated with [Claude Code](https://claude.ai/code)