### PR TITLE
Add signAllTransactions support for batch Solana transaction signing

### DIFF
--- a/src/toolkit/types.ts
+++ b/src/toolkit/types.ts
@@ -34,6 +34,7 @@ export interface SolanaSigner {
     publicKey: { toBase58: () => string }; // solana provider
 
     signTransaction: (tx: any) => Promise<any>;
+    signAllTransactions?: (txs: any[]) => Promise<any[]>;
 }
 
 export function isEtherSigner(signer: any): boolean {


### PR DESCRIPTION
## Summary
- Add optional `signAllTransactions` method to `SolanaSigner` interface
- Implement batch signing optimization in Jito and QuickNode Jito clients
- Add graceful fallback to individual signing for wallet compatibility

## Benefits
- **Improved UX**: Reduces wallet prompt frequency for multiple Solana transactions
- **Better Performance**: Faster signing process when `signAllTransactions` is available
- **Backward Compatibility**: Graceful fallback ensures compatibility with all Solana wallets

## Implementation Details
- Updated `SolanaSigner` interface to include optional `signAllTransactions?: (txs: any[]) => Promise<any[]>`
- Modified Jito clients to detect and use batch signing when available (multiple transactions)
- Maintains individual signing fallback for single transactions or unsupported wallets
- Preserves all existing error handling and transaction confirmation logic

## Test Plan
- [x] TypeScript compilation passes
- [x] Existing tests continue to pass
- [x] Maintains backward compatibility with existing Solana wallet implementations

🤖 Generated with [Claude Code](https://claude.ai/code)