### PR TITLE
Improve error visibility in Solana transaction failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unifai-sdk",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "unifai-sdk",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unifai-sdk",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "unifai-sdk-js is the Javascript/Typescript SDK for UnifAI, an AI native platform for dynamic tools and agent to agent communication.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/toolkit/transaction.ts
+++ b/src/toolkit/transaction.ts
@@ -501,7 +501,18 @@ export class TransactionAPI extends API {
             }
 
             if (transactionResult.value.err) {
-                throw new Error(`Transaction failed: ${transactionResult.value.err}`);
+                let errorDetail: string;
+                if (typeof transactionResult.value.err === 'object') {
+                    try {
+                        errorDetail = JSON.stringify(transactionResult.value.err, null, 2);
+                    } catch (jsonError) {
+                        // Fallback for circular references or other JSON.stringify errors
+                        errorDetail = transactionResult.value.err.toString();
+                    }
+                } else {
+                    errorDetail = String(transactionResult.value.err);
+                }
+                throw new Error(`Transaction failed: ${errorDetail}`);
             }
 
             return { hash: signature }


### PR DESCRIPTION
## Summary
- Replace `[object Object]` error messages with detailed JSON serialization of transaction error objects
- Makes debugging Solana transaction failures much easier by showing actual error details

## Test plan
- [ ] Test with failing Solana transactions to verify error details are now visible
- [ ] Verify successful transactions still work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)