### PR TITLE
Add toolkit health monitoring with searchTools polling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unifai-sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "unifai-sdk",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unifai-sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "unifai-sdk-js is the Javascript/Typescript SDK for UnifAI, an AI native platform for dynamic tools and agent to agent communication.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/toolkit/api.ts
+++ b/src/toolkit/api.ts
@@ -11,6 +11,10 @@ export class ToolkitAPI extends API {
     super(config);
   }
 
+  public async me(): Promise<any> {
+    return await this.request('GET', '/toolkits/me');
+  }
+
   public async updateToolkit(info: Record<string, any>): Promise<void> {
     await this.request('POST', '/toolkits/fields/', { json: info });
   }

--- a/src/tools/api.ts
+++ b/src/tools/api.ts
@@ -8,7 +8,7 @@ export class ToolsAPI extends API {
     super(config);
   }
 
-  public async searchTools(args: Record<string, string>): Promise<any> {
+  public async searchTools(args: Record<string, any>): Promise<any> {
     return await this.request('GET', '/actions/search', { params: args });
   }
 


### PR DESCRIPTION
## Summary
- Add me() method to Toolkit that calls api.me to get toolkit ID
- Implement health monitoring by polling searchTools() every 30 seconds when action handlers exist
- Add robust retry logic with exponential backoff (2s, 4s delays) before reconnecting

## Test plan
- [ ] Verify me() method returns toolkit information correctly
- [ ] Test that polling starts only when action handlers are registered
- [ ] Confirm retry logic works with network failures
- [ ] Validate reconnection triggers after 3 failed retry attempts
- [ ] Ensure proper cleanup of intervals during reconnection cycles

🤖 Generated with [Claude Code](https://claude.ai/code)