### PR TITLE
add pacifica

### DIFF
--- a/examples/test_pacifica.ts
+++ b/examples/test_pacifica.ts
@@ -1,0 +1,152 @@
+import { config } from 'dotenv';
+import OpenAI from 'openai';
+import { Tools } from '../src';
+import { TransactionAPI } from '../src/toolkit/transaction/index';
+import { Wallet, JsonRpcProvider } from 'ethers';
+import { Keypair, VersionedTransaction } from '@solana/web3.js';
+import nacl from 'tweetnacl';
+// @ts-ignore
+const bs58 = require('bs58');
+
+config({ path: 'examples/.env' });
+
+
+const EVM_PRIVATE_KEY = process.env.EVM_PRIVATE_KEY || '';
+const EVM_RPC_URL = process.env.EVM_RPC_URL || '';
+const SOLANA_PRIVATE_KEY = process.env.SOLANA_PRIVATE_KEY || '';
+
+async function run(msg: string) {
+  const tools = new Tools({ apiKey: process.env.UNIFAI_AGENT_API_KEY || '' });
+  const txnApi = new TransactionAPI({
+    endpoint: 'http://localhost:8001/api',
+    apiKey: process.env.UNIFAI_AGENT_API_KEY || ''
+  });
+
+
+  const openai = new OpenAI({
+    apiKey: process.env.OPENAI_API_KEY,
+    baseURL: 'https://api.deepseek.com/v1/',
+  });
+
+  // Initialize unified signer that automatically routes to correct chain
+  // Create EVM wallet with provider
+  let evmWallet: Wallet | null = null;
+  if (EVM_PRIVATE_KEY) {
+    if (!EVM_RPC_URL) {
+      throw new Error('EVM_RPC_URL is required when using EVM_PRIVATE_KEY');
+    }
+    const provider = new JsonRpcProvider(EVM_RPC_URL);
+    evmWallet = new Wallet(EVM_PRIVATE_KEY, provider);
+  }
+
+  // Support multiple Solana private key formats
+  const solanaKeypair = SOLANA_PRIVATE_KEY ? (() => {
+    try {
+      // Try as base58 string (most common, from Phantom/Solflare export)
+      if (SOLANA_PRIVATE_KEY.length > 80 && !SOLANA_PRIVATE_KEY.startsWith('[')) {
+        return Keypair.fromSecretKey(bs58.decode(SOLANA_PRIVATE_KEY));
+      }
+      // Try as JSON array (e.g., [1,2,3,...])
+      if (SOLANA_PRIVATE_KEY.startsWith('[')) {
+        return Keypair.fromSecretKey(Uint8Array.from(JSON.parse(SOLANA_PRIVATE_KEY)));
+      }
+      // Try as hex string
+      return Keypair.fromSecretKey(Buffer.from(SOLANA_PRIVATE_KEY, 'hex'));
+    } catch (error) {
+      console.error('Failed to parse Solana private key:', error);
+      return null;
+    }
+  })() : null;
+
+  const signer: any = {
+    // Spread Solana signer methods (publicKey, signTransaction)
+    ...(solanaKeypair && {
+      publicKey: solanaKeypair.publicKey,
+      signTransaction: async (tx: any) => {
+        if (tx instanceof VersionedTransaction) {
+          tx.sign([solanaKeypair]);
+        } else {
+          tx.sign(solanaKeypair);
+        }
+        return tx;
+      },
+      signMessage: async (message: Uint8Array) => {
+        const signature = nacl.sign.detached(message, solanaKeypair.secretKey);
+        return signature;
+      }
+    }),
+  };
+
+  const systemPrompt = `You are a trading platforms assistant. 
+  When the user wants to trade on Pacifica,:
+  1. First, use retrieveMarket to find the market symbol and market details.
+  2. Then, use the retrieved information to call placeLimitOrder or placeMarketOrder or cancelOrder based on the user's intent.
+  3. Always output standard tool_calls.`;
+
+  // const systemPrompt = `You are a trading platforms assistant. 
+  // When the user wants to cancel an order on Pacifica,
+  // 1. If the user wants to cancel a SPECIFIC order, first user retrieveMarket to find market symbols, then call cancelOrder.
+  // 2. If the user wants to cancel ALL orders, call cancelAllOrders.
+  // 3. Information Retrieval: If you lack a market symbol or order ID, always use the retrieval tools first.
+  // 4. Always output standard tool_calls.`;
+
+  const messages: any[] = [
+    { content: systemPrompt, role: 'system' },
+    { content: msg, role: 'user' },
+  ];
+
+
+  const availableTools = await tools.getTools({ staticToolkits: ['Pacifica'] });
+
+  while (true) {
+    const response = await openai.chat.completions.create({
+      model: 'deepseek-chat',
+      messages,
+      tools: availableTools,
+    });
+
+    const message = response.choices[0].message;
+    messages.push(message);
+
+    if (message.content) console.log(`[Assistant]: ${message.content}`);
+
+    if (!message.tool_calls || message.tool_calls.length === 0) break;
+
+    console.log('🛠 toolkit:', message.tool_calls.map(tc => tc.function.name));
+
+
+    const results = await tools.callTools(message.tool_calls);
+
+
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      if (result.content && typeof result.content === 'string') {
+        try {
+          const parsed = JSON.parse(result.content);
+
+          const txId = parsed?.payload?.txId || parsed?.txId;
+
+          if (txId) {
+
+            const txResult = await txnApi.signAndSendTransaction(txId, signer);
+
+            if (txResult.hash) {
+              parsed.payload = { ...parsed.payload, status: 'success', hash: txResult.hash };
+              results[i].content = JSON.stringify(parsed);
+            }
+          }
+        } catch (e) {
+          console.error('error:', e);
+        }
+      }
+    }
+
+    messages.push(...results);
+  }
+}
+
+
+// run("Place a limit order to buy 0.13 SOL at $83 on the Pacifica SOL market.").catch(console.error);
+// run("Place a market order to buy 0.12 SOL on the Pacifica SOL market.").catch(console.error);
+// run("Cancel my order with ID 5801807344 on the Pacifica SOL market.");
+run("Use the toolkit to cancel all my orders on Pacifica.");

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@polymarket/clob-client": "^4.18.0",
         "@solana/web3.js": "^1.98.2",
         "axios": "^1.13.1",
-        "bs58": "^4.0.0",
+        "bs58": "^4.0.1",
         "commander": "^12.0.0",
         "ethers": "^6.14.4",
         "jito-js-rpc": "^0.2.2",
@@ -2807,7 +2807,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
       "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
-      "license": "MIT",
       "dependencies": {
         "base-x": "^3.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -18,16 +18,16 @@
     "test": "jest"
   },
   "dependencies": {
-    "bs58": "^4.0.0",
-    "commander": "^12.0.0",
-    "js-yaml": "^4.1.0",
     "@modelcontextprotocol/sdk": "^1.3.0",
     "@nktkas/hyperliquid": "^0.22.1",
     "@polymarket/clob-client": "^4.18.0",
     "@solana/web3.js": "^1.98.2",
     "axios": "^1.13.1",
+    "bs58": "^4.0.1",
+    "commander": "^12.0.0",
     "ethers": "^6.14.4",
     "jito-js-rpc": "^0.2.2",
+    "js-yaml": "^4.1.0",
     "json-bigint": "^1.0.0",
     "p-limit": "^3.0.0",
     "socks-proxy-agent": "^8.0.5",
@@ -35,8 +35,8 @@
     "ws": "^8.0.0"
   },
   "devDependencies": {
-    "@types/js-yaml": "^4.0.0",
     "@types/jest": "^29.0.0",
+    "@types/js-yaml": "^4.0.0",
     "@types/json-bigint": "^1.0.0",
     "@types/node": "^18.0.0",
     "@types/url-join": "^4.0.3",

--- a/src/toolkit/transaction/index.ts
+++ b/src/toolkit/transaction/index.ts
@@ -8,6 +8,7 @@ import { EVMHandler } from './evm-handler';
 import { PolymarketHandler } from './polymarket-handler';
 import { HyperliquidHandler } from './hyperliquid-handler';
 import { JitoHandler } from './jito-handler';
+import { PacificaHandler } from './pacifica-handler';
 
 export class TransactionAPI extends BaseTransactionAPI {
     private solanaHandler: SolanaHandler;
@@ -15,6 +16,7 @@ export class TransactionAPI extends BaseTransactionAPI {
     private polymarketHandler: PolymarketHandler;
     private hyperliquidHandler: HyperliquidHandler;
     private jitoHandler: JitoHandler;
+    private pacificaHandler: PacificaHandler;
 
     constructor(config: APIConfig) {
         super(config);
@@ -26,6 +28,9 @@ export class TransactionAPI extends BaseTransactionAPI {
         );
         this.hyperliquidHandler = new HyperliquidHandler(this.rateLimiter);
         this.jitoHandler = new JitoHandler(this.rateLimiter);
+        this.pacificaHandler = new PacificaHandler(this.rateLimiter, config.maxPollTimes, config.pollInterval,
+            (chain: string, name: string, txData: any) => this.sendTransaction(chain, name, txData)
+        );
     }
 
     // Sign and Sends a transaction to blockchains.
@@ -54,6 +59,8 @@ export class TransactionAPI extends BaseTransactionAPI {
         if (!transactions || transactions.length === 0) {
             throw new Error('No transactions to send.')
         }
+
+        console.log(transactions);
 
         const jitoDecision = this.jitoHandler.shouldUseJito(
             transactions,
@@ -144,7 +151,38 @@ export class TransactionAPI extends BaseTransactionAPI {
                         }
                         break;
                     case 'solana': // Solana
-                        res = await this.solanaHandler.sendTransaction(signer as SolanaSigner, tx, config);
+                        switch (tx.name) {
+                            case 'Pacifica-LimitOrder':
+                                res = await this.pacificaHandler.sendLimitOrderTransaction(
+                                    signer as SolanaSigner,
+                                    tx,
+                                    address,
+                                );
+                                break;
+                            case 'Pacifica-MarketOrder':
+                                res = await this.pacificaHandler.sendMarketOrderTransaction(
+                                    signer as SolanaSigner,
+                                    tx,
+                                    address,
+                                );
+                                break;
+                            case 'Pacifica-CancelOrder':
+                                res = await this.pacificaHandler.sendCancelOrderTransaction(
+                                    signer as SolanaSigner,
+                                    tx,
+                                    address,
+                                );
+                                break;
+                            case 'Pacifica-CancelAllOrders':
+                                res = await this.pacificaHandler.sendCancelAllOrdersTransaction(
+                                    signer as SolanaSigner,
+                                    tx,
+                                    address,
+                                );
+                                break;
+                            default:
+                                res = await this.solanaHandler.sendTransaction(signer as SolanaSigner, tx, config);
+                        }
                         break;
                     case 'hyperliquid': // hyperliquid orders
                         res = await this.hyperliquidHandler.sendTransaction(signer as EtherSigner | WagmiSigner, tx);

--- a/src/toolkit/transaction/index.ts
+++ b/src/toolkit/transaction/index.ts
@@ -60,8 +60,6 @@ export class TransactionAPI extends BaseTransactionAPI {
             throw new Error('No transactions to send.')
         }
 
-        console.log(transactions);
-
         const jitoDecision = this.jitoHandler.shouldUseJito(
             transactions,
             config?.useJito,

--- a/src/toolkit/transaction/pacifica-handler.ts
+++ b/src/toolkit/transaction/pacifica-handler.ts
@@ -180,7 +180,7 @@ export class PacificaHandler {
       );
 
       return {
-        hash: res?.data?.order_id,
+        hash: undefined,
         data: res
       };
     } catch (error) {
@@ -234,7 +234,7 @@ export class PacificaHandler {
       );
 
       return {
-        hash: res?.data?.order_id,
+        hash: undefined,
         data: res
       };
     } catch (error) {

--- a/src/toolkit/transaction/pacifica-handler.ts
+++ b/src/toolkit/transaction/pacifica-handler.ts
@@ -1,0 +1,245 @@
+import { RateLimiter, DEFAULT_CONFIG } from "../../common";
+import { SolanaSigner } from "../types";
+import { encodeBase58 } from 'ethers/utils';
+
+function sortObjectKeys(obj: any): any {
+  return Object.keys(obj).sort().reduce((acc: any, key: any) => {
+    let value = obj[key];
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      value = sortObjectKeys(value);
+    }
+    acc[key] = value;
+    return acc;
+  }, {});
+}
+
+
+export class PacificaHandler {
+  constructor(
+    private rateLimiter?: RateLimiter,
+    private maxPollTimes: number = DEFAULT_CONFIG.MAX_POLL_TIMES,
+    private pollInterval: number = DEFAULT_CONFIG.POLL_INTERVAL,
+    private sendTransactionProxy?: (
+      chain: string,
+      name: string,
+      txData: any
+    ) => Promise<any>
+  ) { }
+
+  async sendMarketOrderTransaction(
+    signer: SolanaSigner,
+    tx: any,
+    address: string
+  ): Promise<{ hash?: string; data: any }> {
+    try {
+      const orderTx = JSON.parse(tx.hex);
+      const header = orderTx.header;
+      const payload = orderTx.payload;
+
+      const dataToSign = {
+        ...header,
+        "data": payload,
+      }
+
+      const sortedData = sortObjectKeys(dataToSign);
+
+      const messageString = JSON.stringify(sortedData);
+
+      let signature: string;
+
+      const messageBytes = new TextEncoder().encode(messageString);
+
+      if (signer.signMessage) {
+        const signedMessage = await signer.signMessage(messageBytes);
+        const signatureUint8 = signedMessage instanceof Uint8Array ? signedMessage : signedMessage.signature;
+        signature = encodeBase58(signatureUint8);
+      } else {
+        throw new Error("Wallet does not support signMessage");
+      }
+
+      const requestBody = {
+        account: address,
+        signature: signature,
+        timestamp: orderTx.header.timestamp,
+        expiry_window: orderTx.header.expiry_window,
+        ...orderTx.payload,
+      };
+
+      const res = await this.sendTransactionProxy?.(
+        "solana",
+        "Pacifica-PlaceMarketOrder",
+        { data: requestBody }
+      );
+
+      return {
+        hash: res?.data?.order_id,
+        data: res
+      };
+    } catch (error) {
+      throw new Error(`PacificaSendOrderTransaction Error: ${error}`);
+    }
+  }
+
+  async sendLimitOrderTransaction(
+    signer: SolanaSigner,
+    tx: any,
+    address: string
+  ): Promise<{ hash?: string; data: any }> {
+    try {
+      const orderTx = JSON.parse(tx.hex);
+      const header = orderTx.header;
+      const payload = orderTx.payload;
+
+      const dataToSign = {
+        ...header,
+        "data": payload,
+      }
+
+      const sortedData = sortObjectKeys(dataToSign);
+
+      const messageString = JSON.stringify(sortedData);
+
+      let signature: string;
+
+      const messageBytes = new TextEncoder().encode(messageString);
+
+      if (signer.signMessage) {
+        const signedMessage = await signer.signMessage(messageBytes);
+        const signatureUint8 = signedMessage instanceof Uint8Array ? signedMessage : signedMessage.signature;
+        signature = encodeBase58(signatureUint8);
+      } else {
+        throw new Error("Wallet does not support signMessage");
+      }
+
+      const requestBody = {
+        account: address,
+        signature: signature,
+        timestamp: orderTx.header.timestamp,
+        expiry_window: orderTx.header.expiry_window,
+        ...orderTx.payload,
+      };
+
+      const res = await this.sendTransactionProxy?.(
+        "solana",
+        "Pacifica-PlaceLimitOrder",
+        { data: requestBody }
+      );
+
+      return {
+        hash: res?.data?.order_id,
+        data: res
+      };
+    } catch (error) {
+      throw new Error(`PacificaSendOrderTransaction Error: ${error}`);
+    }
+  }
+
+  async sendCancelOrderTransaction(
+    signer: SolanaSigner,
+    tx: any,
+    address: string
+  ): Promise<{ hash?: string; data: any }> {
+    try {
+      const orderTx = JSON.parse(tx.hex);
+      const header = orderTx.header;
+      const payload = orderTx.payload;
+
+      const dataToSign = {
+        ...header,
+        "data": payload,
+      }
+
+      const sortedData = sortObjectKeys(dataToSign);
+
+      const messageString = JSON.stringify(sortedData);
+
+      let signature: string;
+
+      const messageBytes = new TextEncoder().encode(messageString);
+
+      if (signer.signMessage) {
+        const signedMessage = await signer.signMessage(messageBytes);
+        const signatureUint8 = signedMessage instanceof Uint8Array ? signedMessage : signedMessage.signature;
+        signature = encodeBase58(signatureUint8);
+      } else {
+        throw new Error("Wallet does not support signMessage");
+      }
+
+      const requestBody = {
+        account: address,
+        signature: signature,
+        timestamp: orderTx.header.timestamp,
+        expiry_window: orderTx.header.expiry_window,
+        ...orderTx.payload,
+      };
+
+      const res = await this.sendTransactionProxy?.(
+        "solana",
+        "Pacifica-CancelOrder",
+        { data: requestBody }
+      );
+
+      return {
+        hash: res?.data?.order_id,
+        data: res
+      };
+    } catch (error) {
+      throw new Error(`PacificaSendOrderTransaction Error: ${error}`);
+    }
+  }
+
+  async sendCancelAllOrdersTransaction(
+    signer: SolanaSigner,
+    tx: any,
+    address: string
+  ): Promise<{ hash?: string; data: any }> {
+    try {
+      const orderTx = JSON.parse(tx.hex);
+      const header = orderTx.header;
+      const payload = orderTx.payload;
+
+      const dataToSign = {
+        ...header,
+        "data": payload,
+      }
+
+      const sortedData = sortObjectKeys(dataToSign);
+
+      const messageString = JSON.stringify(sortedData);
+
+      let signature: string;
+
+      const messageBytes = new TextEncoder().encode(messageString);
+
+      if (signer.signMessage) {
+        const signedMessage = await signer.signMessage(messageBytes);
+        const signatureUint8 = signedMessage instanceof Uint8Array ? signedMessage : signedMessage.signature;
+        signature = encodeBase58(signatureUint8);
+      } else {
+        throw new Error("Wallet does not support signMessage");
+      }
+
+      const requestBody = {
+        account: address,
+        signature: signature,
+        timestamp: orderTx.header.timestamp,
+        expiry_window: orderTx.header.expiry_window,
+        ...orderTx.payload,
+      };
+
+      const res = await this.sendTransactionProxy?.(
+        "solana",
+        "Pacifica-CancelAllOrders",
+        { data: requestBody }
+      );
+
+      return {
+        hash: res?.data?.order_id,
+        data: res
+      };
+    } catch (error) {
+      throw new Error(`PacificaSendOrderTransaction Error: ${error}`);
+    }
+  }
+
+}

--- a/src/toolkit/types.ts
+++ b/src/toolkit/types.ts
@@ -1,57 +1,58 @@
 
 export interface SendConfig {
-    rpcUrls?: string[], // rpc urls to send transactions
-    proxyUrl?: string   // proxy server to forward transaction
-    txData?: any        // transaction data to send
-    txInterval?: number // interval(seconds) to between transactions
-    onFailure?: 'skip' | 'stop' // skip: skip a failure transaction and continue, stop: stop the failure transaction and throw an error
-    useJito?: boolean // enable/disable jito for solana transactions
-    jitoProvider?: 'jito' | 'quicknode' // jito provider: jito (original) or quicknode, defaults to quicknode
-    jitoEndpoint?: string // jito block engine endpoint (for original jito provider) or quicknode endpoint (for quicknode provider)
-    jitoApiKey?: string // jito api key (for original jito provider)
-    jitoTipAmount?: number // jito tip amount in lamports
-    broadcastMode?: 'sequential' | 'concurrent' // sequential: try rpcs one by one (default), concurrent: send to all rpcs at once, success if any succeeds
+  rpcUrls?: string[], // rpc urls to send transactions
+  proxyUrl?: string   // proxy server to forward transaction
+  txData?: any        // transaction data to send
+  txInterval?: number // interval(seconds) to between transactions
+  onFailure?: 'skip' | 'stop' // skip: skip a failure transaction and continue, stop: stop the failure transaction and throw an error
+  useJito?: boolean // enable/disable jito for solana transactions
+  jitoProvider?: 'jito' | 'quicknode' // jito provider: jito (original) or quicknode, defaults to quicknode
+  jitoEndpoint?: string // jito block engine endpoint (for original jito provider) or quicknode endpoint (for quicknode provider)
+  jitoApiKey?: string // jito api key (for original jito provider)
+  jitoTipAmount?: number // jito tip amount in lamports
+  broadcastMode?: 'sequential' | 'concurrent' // sequential: try rpcs one by one (default), concurrent: send to all rpcs at once, success if any succeeds
 }
 
 export type Signer = EtherSigner | WagmiSigner | SolanaSigner;
 
 export interface EtherSigner {
-    address: string;
+  address: string;
 
-    sendTransaction: (tx: any) => Promise<any>;
-    signTypedData: (domain: any, types: any, value: any) => Promise<string>
+  sendTransaction: (tx: any) => Promise<any>;
+  signTypedData: (domain: any, types: any, value: any) => Promise<string>
 }
 
 export interface WagmiSigner {
-    account: any
-    getAddresses: () => Promise<string[]>;
+  account: any
+  getAddresses: () => Promise<string[]>;
 
-    sendTransaction: (tx: any) => Promise<any>;
-    signTypedData: (data: any) => Promise<string>
-    waitForTransactionReceipt?: (h: {hash: string}) => Promise<any>
+  sendTransaction: (tx: any) => Promise<any>;
+  signTypedData: (data: any) => Promise<string>
+  waitForTransactionReceipt?: (h: { hash: string }) => Promise<any>
 }
 
 export interface SolanaSigner {
-    publicKey: { toBase58: () => string }; // solana provider
+  publicKey: { toBase58: () => string }; // solana provider
+  signMessage?: (message: Uint8Array) => Promise<{ signature: Uint8Array } | Uint8Array>;
 
-    signTransaction: (tx: any) => Promise<any>;
-    signAllTransactions?: (txs: any[]) => Promise<any[]>;
+  signTransaction: (tx: any) => Promise<any>;
+  signAllTransactions?: (txs: any[]) => Promise<any[]>;
 }
 
 export function isEtherSigner(signer: any): boolean {
-    return typeof signer === 'object' && 'address' in signer &&
-        'sendTransaction' in signer && 'signTypedData' in signer
+  return typeof signer === 'object' && 'address' in signer &&
+    'sendTransaction' in signer && 'signTypedData' in signer
 }
 
 export function isWagmiSigner(signer: any): boolean {
-    return typeof signer === 'object' && 'account' in signer &&
-        'getAddresses' in signer && 'sendTransaction' in signer &&
-        'signTypedData' in signer
+  return typeof signer === 'object' && 'account' in signer &&
+    'getAddresses' in signer && 'sendTransaction' in signer &&
+    'signTypedData' in signer
 }
 
 export function isSolanaSigner(signer: any): boolean {
-    return typeof signer === 'object' && 'publicKey' in signer &&
-        'signTransaction' in signer
+  return typeof signer === 'object' && 'publicKey' in signer &&
+    'signTransaction' in signer
 }
 
 export async function getSignerAddress(signer: Signer): Promise<string> {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new Solana message-signing flow and special-cased transaction routing for Pacifica order/cancel actions; signature formatting or routing mistakes could cause failed or unintended order API calls.
> 
> **Overview**
> Adds **Pacifica trading transaction support** to `TransactionAPI` by routing Solana transactions named `Pacifica-*` through a new `PacificaHandler` that signs a deterministic JSON payload via `signMessage` and forwards it to the `/tx/sendtransaction` proxy for placing/canceling orders.
> 
> Introduces an `examples/test_pacifica.ts` script to exercise the Pacifica toolkit end-to-end (tool calls → tx build → sign+send), expands `SolanaSigner` to optionally support `signMessage`, and bumps `bs58` to `^4.0.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9d212b2b8a30593bc44131e4906303451c86f63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->